### PR TITLE
Fix dotenv loading order

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,13 @@
+from dotenv import load_dotenv
+load_dotenv()
+
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from bot.bot import teams_bot_router
 from digest.weekly_summary import schedule_weekly_digest
 from dashboard.routes import dashboard_router
 from auth.middleware import verify_token
-from fastapi.middleware.cors import CORSMiddleware
-from dotenv import load_dotenv
 import uvicorn
-
-load_dotenv()
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- ensure `.env` variables load before importing modules that rely on them

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685daead5bf8832382f49475233b5586